### PR TITLE
Bump mercenary version

### DIFF
--- a/octopress.gemspec
+++ b/octopress.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "mercenary", "~> 0.1.0"
+  spec.add_runtime_dependency "mercenary", "~> 0.2.1"
   spec.add_runtime_dependency "jekyll", "~> 1.4.2"
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
This fixes a bug where `-v` and `--version` don't work.
