### PR TITLE
Adding scaffold to gem

### DIFF
--- a/octopress.gemspec
+++ b/octopress.gemspec
@@ -13,9 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://octopress.org"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files | grep -iE "^(bin\/|lib\/|assets\/|changelog|readme|license|site|local|scaffold\/)"`.split("\n")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.files         = `git ls-files -z`.split("\x0").grep(/^(bin\/|lib\/|assets\/|changelog|readme|license|site|local)/i)
   
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
This fixes #67 by changing the gemspec to include the scaffold folder.

Also updating the the gemspec so it's a simple bash pipeline that includes the grep, which makes it easy to see what it returns.
and removed adding the spec.files value twice.