### PR TITLE
trap SIGINT and abort before calling gets. fixes #161

### DIFF
--- a/lib/octopress/commands/helpers.rb
+++ b/lib/octopress/commands/helpers.rb
@@ -77,6 +77,7 @@ module Octopress
 
       print "Which do you want to #{action}? (enter a number): "
       $stdout.flush
+      trap("SIGINT") { puts ''; abort "#{action.capitalize} canceled: Ctrl-C hit." }
       post = $stdin.gets.strip.to_i
 
       # Give a newline for further output


### PR DESCRIPTION
to avoid ugly callstack when hitting Ctrl-C while octopress sits in gets call
