### PR TITLE
Update docs to note init requires a jekyll blog set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Run `octopress --help` to list sub commands and `octopress <subcommand> --help` 
 $ octopress init <PATH> [options]
 ```
 
-This will copy Octopress's scaffolding into the specified directory. Use the `--force` option to overwrite existing files. The scaffolding is pretty simple:
+This will copy Octopress's scaffolding into the specified directory, which should be an already initialized Jekyll blog. Use the `--force` option to overwrite existing files. The scaffolding is pretty simple:
 
 ```
 _templates/


### PR DESCRIPTION
I notice that the init command is a bit confusingly worded in the readme, and it isn't specifically clear that it requires the blog to already be initialized, so this just updates the readme to fix that. 
