### PR TITLE
Page#date_slug issues a usefull message on error

### DIFF
--- a/lib/octopress/page.rb
+++ b/lib/octopress/page.rb
@@ -198,7 +198,12 @@ module Octopress
     end
 
     def date_slug
-      @options['date'].split('T')[0]
+      begin
+        Time.parse(@options['date']).strftime('%Y-%m-%d')
+      rescue => error
+        puts 'Could not parse date. Try formatting it like YYYY-MM-DD HH:MM'
+        abort error.message
+      end
     end
 
     # Returns a slug extracted from a path


### PR DESCRIPTION
for some reason 'date' field could be missing from the post metadata.
this fix tries to tell the user what is going the wrong way.

fixes #168
