### PR TITLE
Fix YAML front-matter updating

### DIFF
--- a/lib/octopress/post.rb
+++ b/lib/octopress/post.rb
@@ -67,13 +67,22 @@ module Octopress
       end
     end
 
+    # Extracts the YAML front matter
+    #
+    def yaml_front_matter
+      @yaml_front_matter ||= begin
+        match = read.match(/\A---\s*\n(.*?\n?)^---\s*$\n?/m)
+        match[1] || ""
+      end
+    end
+
     # Get title from post file
     #
     def read_post_yaml(key)
-      match = read.match(/#{key}:\s*(.+)?$/)
+      match = yaml_front_matter.match(/^\s*#{key}:\s*(.+)?$/)
       match[1] if match
     end
-    
+
     # Get content from draft post file
     # also update the draft's date configuration
     #


### PR DESCRIPTION
When publishing a draft without a date, the code that inserts the publish date into the post was not restricting itself to the YAML front-matter section of the post.  Rather, it would search anywhere in the post for the `date:` and `title:` keys and attempt to parse their values.

If a draft didn't have a date in the front matter, but had the pattern `date:` somewhere in the body of the post, `read_post_yaml` would find the pattern and attempt to parse the rest of the line.

If it was successful, it would then try to remove the old date entry and add a new one in the front matter, corrupting the body of the post.

I attempted to fix this by using `YAML.safe_load` to parse the front-matter, but ran into two issues:

1. It would parse the date as a date, causing breakage in other parts of the code that were expecting strings.
2. `YAML.safe_load` doesn't tell you where it finished parsing, so there was no way to get at the rest of the post after the front matter without using the regex anyway.

In the end, I opted for a simpler approach: use the regex (the same one that Jekyll uses) to split out the front matter and the body, update the front matter, and reassemble the new front matter with the existing body.

I was not able to craft a proper `clash` test for this fix; all my attempts to `echo` some additional content into the draft failed unless I ran with the `-t` flag.  I'm not sure why that is.