### PR TITLE
KnP: fix publish FrozenError

### DIFF
--- a/lib/octopress/page.rb
+++ b/lib/octopress/page.rb
@@ -151,7 +151,11 @@ module Octopress
     # Render Liquid vars in YAML front-matter.
     def parse_template(input)
 
-      if @config['titlecase']
+      # Fix titlecase FrozenError when publish a draft to post
+      # On converting a draft to post parse_template is called before
+      # Post.read_post_yaml. That's why the title is empty.
+      #
+      if !@options['title'].empty? && @config['titlecase']
         @options['title'].titlecase!
       end
 


### PR DESCRIPTION
Hello,

I have just started using Octopress for my new Jekyll blog and I got

``
titlecase.rb:34:in `replace': can't modify frozen String: "" (FrozenError)
``

on publish a draft.
I went through the source code and I found that on converting a draft to post parse_template is called before Post::read_post_yaml. That's why the @options['title'] is empty and consequently caused the FrozenError.
I hope this helps.

Thank you!