### PR TITLE
Fix FrozenError exception in `publish`

### DIFF
--- a/lib/octopress/page.rb
+++ b/lib/octopress/page.rb
@@ -151,7 +151,7 @@ module Octopress
     # Render Liquid vars in YAML front-matter.
     def parse_template(input)
 
-      if @config['titlecase']
+      if @config['titlecase'] && @options['title'] != ""
         @options['title'].titlecase!
       end
 


### PR DESCRIPTION
Fixes #186
Fixes #188

Ruby 2.7 changed the behavior of various functions like `NilClass#to_s` to
return a frozen string literal instead of a mutable one. (This was done
for performance reasons, to allow for fewer allocations.)

This is causing some problems in this gem, because the `.titlecase!`
call attempts to mutate the string in place, as seen in this stack
trace:

    ❯ bex octopress publish my-post
    octopress 3.0.11 | Error:  can't modify frozen String: ""
    Traceback (most recent call last):
            32: from /home/jez/.rbenv/versions/2.7.2/bin/bundle:23:in `<main>'
            31: from /home/jez/.rbenv/versions/2.7.2/bin/bundle:23:in `load'
            30: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/libexec/bundle:34:in `<top (required)>'
            29: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/friendly_errors.rb:123:in `with_friendly_errors'
            28: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/libexec/bundle:46:in `block in <top (required)>'
            27: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/cli.rb:24:in `start'
            26: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
            25: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/cli.rb:30:in `dispatch'
            24: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
            23: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
            22: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
            21: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/cli.rb:476:in `exec'
            20: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/cli/exec.rb:28:in `run'
            19: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/cli/exec.rb:63:in `kernel_load'
            18: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/cli/exec.rb:63:in `load'
            17: from /home/jez/.rbenv/versions/2.7.2/bin/octopress:23:in `<top (required)>'
            16: from /home/jez/.rbenv/versions/2.7.2/bin/octopress:23:in `load'
            15: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/octopress-3.0.11/bin/octopress:8:in `<top (required)>'
            14: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
            13: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
            12: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
            11: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
            10: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
             9: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/octopress-3.0.11/lib/octopress/commands/publish.rb:25:in `block (2 levels) in init_with_program'
             8: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/octopress-3.0.11/lib/octopress/commands/publish.rb:32:in `publish_post'
             7: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/octopress-3.0.11/lib/octopress/commands/publish.rb:32:in `new'
             6: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/octopress-3.0.11/lib/octopress/page.rb:30:in `initialize'
             5: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/octopress-3.0.11/lib/octopress/page.rb:136:in `content'
             4: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/octopress-3.0.11/lib/octopress/page.rb:155:in `parse_template'
             3: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/titlecase-0.1.1/lib/titlecase.rb:19:in `titlecase!'
             2: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/titlecase-0.1.1/lib/titlecase.rb:12:in `titlecase'
             1: from /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/titlecase-0.1.1/lib/titlecase.rb:34:in `smart_capitalize!'
    /home/jez/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/titlecase-0.1.1/lib/titlecase.rb:34:in `replace': can't modify frozen String: "" (FrozenError)

We can get around the error by not calling `.titlecase!` if the string
was empty (because `.titlecase!` will be the same result anyways).

Another alternative is to not call `.titlecase!` if
`@options['title'].frozen?`, but that's somewhat of a hammer. If we're
trying to call `.titlecase!` on a frozen, non-empty `String`, that's
probably a bug, and we'd prefer to have that exception get raised so
that we can fix the bug, instead of do something confusing (like not
respect the `titlecase` option).